### PR TITLE
Support MX style switches.

### DIFF
--- a/src/dactyl_keyboard/cad/key.clj
+++ b/src/dactyl_keyboard/cad/key.clj
@@ -47,13 +47,6 @@
 (def mx-overhang-z 1)  ; Estimated, dimension not included in datasheet.
 (def mx-underhang-z 5.004)
 
-;; ;; Hardcode ALPS as our switch type.
-;; (def keyswitch-hole-y alps-hole-y)
-;; (def keyswitch-hole-x alps-hole-x)
-;; (def keyswitch-overhang-x alps-overhang-x)
-;; (def keyswitch-overhang-y alps-overhang-y)
-;; (def keyswitch-cutout-height alps-underhang-z)
-
 (defn resolve-flex [getopt cluster [c0 r0]]
   "Resolve supported keywords in a coordinate pair to names.
   This allows for integers as well as the keywords :first and :last, meaning

--- a/src/dactyl_keyboard/core.clj
+++ b/src/dactyl_keyboard/core.clj
@@ -61,6 +61,8 @@
           (if (= (getopt :wrist-rest :style) :threaded)
             (wrist/threaded-fasteners getopt)))
         (sandbox/negative getopt))
+      (if (= (getopt :switches :style) :mx)
+        (metacluster key/cluster-nubs getopt))
       (if (= (getopt :mcu :support :style) :lock) ; Outside the alcove.
         (aux/mcu-lock-fixture-composite getopt)))
     ;; The remaining elements are visualizations for use in development.
@@ -107,6 +109,7 @@
      [[:key-clusters :aux0] (partial key/cluster-properties :aux0)]
      [[:key-clusters] key/resolve-aliases]
      [[:keycaps] key/keycap-properties]
+     [[:switches] key/keyswitch-dimensions]
      [[:case :rear-housing] body/housing-properties]
      [[:mcu] aux/derive-mcu-properties]
      [[:wrist-rest] wrist/derive-properties]]))

--- a/src/dactyl_keyboard/params.clj
+++ b/src/dactyl_keyboard/params.clj
@@ -115,6 +115,7 @@
 
 ;; Other:
 (spec/def ::supported-key-cluster #{:finger :thumb :aux0})
+(spec/def ::supported-switch-style #{:alps :mx})
 (spec/def ::supported-cluster-style #{:standard :orthographic})
 (spec/def ::supported-cap-style #{:flat :socket :button})
 (spec/def ::supported-mcu-type #{:promicro})
@@ -434,9 +435,14 @@
    [:section [:switches]
     "Electrical switches close a circuit when pressed. They cannot be "
     "printed. This section specifies how much space they need to be "
-    "mounted.\n\n"
-    "There is currently no parameter for style. Only ALPS-compatible switches "
-    "are supported in this version. This includes Matias."]
+    "mounted."]
+   [:parameter [:switches :style]
+    {:default :alps
+     :parse-fn keyword
+     :validate [::supported-switch-style]}
+    "The switch type. One of:\n\n "
+    "* `alps`: ALPS or Matias style switches."
+    "* `mx`: Cherry MX style switches."]
    [:parameter [:switches :travel]
     {:default 1 :parse-fn num}
     "The distance in mm that a keycap can travel vertically when "


### PR DESCRIPTION
Thanks for your effort and dilligence in cleaning up the Clojure code for this project. I added a parameter to choose between ALPS or MX style switches. The switch dimensions are converted to derived parameters, and the ALPS-specific extra lateral cutout for wing flare is applied conditionally. For MX switches, side nubs are added that stabilize the switch. The one caveat here is that the `key-mount-thickness` maybe needs to be set to 4 to size the nubs appropriately. This dimension is not in the MX datasheet, but in the @tshort fork the plate thickness is 4 and the switches are snug. Shorter nubs might not cause a problem, but longer nubs probably would. I don't know if it's more appropriate to warn the user of this or force the thickness.