### PR TITLE
 links to introduction + other DMOTE repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ cluster has been modified to minimize shearing forces.
 
 [![Image of the second working DMOTE](http://viktor.eikman.se/image/dmote-2-top-down-view/display)](http://viktor.eikman.se/article/the-dmote/)
 
+For more images and a brief article click the image.
+
 Parameters have been moved out of the application code itself, into separate
 files that are safe and easy to edit. Use them to change:
 
@@ -16,7 +18,22 @@ files that are safe and easy to edit. Use them to change:
     - Exceptions at any level, down to the position of individual keys.
 - Minor features like LED strips and wrist rests.
 
-For documentation see [doc/](doc/).
+
+### Introduction: [doc/intro.md](doc/intro.md)
+### Documentation: [doc/](doc/)
+---
+## The DMOTE Family
+
+* A stabilizing accesory for the DMOTE: [veikman/dmote-beam](https://github.com/veikman/dmote-beam)
+
+    Want even more tenting control? Hate it when your split keyboard gets out of line? Try the DMOTE Beam.
+
+* Keycaps for ALPS or MX switches: [veikman/dmote-keycap](https://github.com/veikman/dmote-keycap)
+
+    `dmote-keycap` produces a three-dimensional geometry for a keycap: Either a featureless maquette for use in easily rendered previews, or a keycap that you can print and use.
+
+
+---
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ files that are safe and easy to edit. Use them to change:
 ---
 ## The DMOTE Family
 
-* Custom wrist rests:[https://github.com/veikman/dmote-topography](https://github.com/veikman/dmote-topography)
+* Custom wrist rests: [veikman/dmote-topography](https://github.com/veikman/dmote-topography)
 
    Generates custom wrist rests with smooth organic topography. The topography is based on a bivariate normal distribution function multiplied by a logarithmic mound shape.
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,14 @@ files that are safe and easy to edit. Use them to change:
 - Minor features like LED strips and wrist rests.
 
 
-### Introduction: [doc/intro.md](doc/intro.md)
+### Introduction & Getting Started: [doc/intro.md](doc/intro.md)
 ### Documentation: [doc/](doc/)
 ---
 ## The DMOTE Family
+
+* Custom wrist rests:[https://github.com/veikman/dmote-topography](https://github.com/veikman/dmote-topography)
+
+   Generates custom wrist rests with smooth organic topography. The topography is based on a bivariate normal distribution function multiplied by a logarithmic mound shape.
 
 * A stabilizing accesory for the DMOTE: [veikman/dmote-beam](https://github.com/veikman/dmote-beam)
 


### PR DESCRIPTION
I don't know, to me it seems like fewer clicks to get to the introduction and showing the 'accessories' available could increase uptake.